### PR TITLE
Edit form correctly handles "ui-directory.edit-local" permission

### DIFF
--- a/src/components/DirectoryEntryForm/DirectoryEntryForm.js
+++ b/src/components/DirectoryEntryForm/DirectoryEntryForm.js
@@ -36,17 +36,26 @@ class DirectoryEntryForm extends React.Component {
     values: PropTypes.object,
   }
 
-  state = {
-    sectionsShared: {
-      directoryEntryFormInfo: true,
-      directoryEntryFormContactInfo: true,
-      directoryEntryFormServices: false,
-      directoryEntryFormCustProps: false,
-    },
-    sectionsLocal: {
-      localDirectoryEntryFormInfo: false,
-    },
-    tab: 'shared',
+  constructor(props) {
+    super(props);
+
+    const { stripes } = props;
+    this.localOnly = (stripes.hasPerm('ui-directory.edit-local') &&
+                      !stripes.hasPerm('ui-directory.edit-all') &&
+                      !(stripes.hasPerm('ui-directory.edit-self')));
+
+    this.state = {
+      sectionsShared: {
+        directoryEntryFormInfo: true,
+        directoryEntryFormContactInfo: true,
+        directoryEntryFormServices: false,
+        directoryEntryFormCustProps: false,
+      },
+      sectionsLocal: {
+        localDirectoryEntryFormInfo: this.localOnly,
+      },
+      tab: this.localOnly ? 'local' : 'shared',
+    };
   }
 
   getSectionProps() {
@@ -98,13 +107,15 @@ class DirectoryEntryForm extends React.Component {
       <div>
         <Layout className="textCentered">
           <ButtonGroup>
-            <Button
-              onClick={() => this.setState({ tab: 'shared' })}
-              buttonStyle={tab === 'shared' ? 'primary' : 'default'}
-              id="clickable-nav-shared"
-            >
-              <FormattedMessage id="ui-directory.information.tab.shared" />
-            </Button>
+            {!this.localOnly &&
+              <Button
+                onClick={() => this.setState({ tab: 'shared' })}
+                buttonStyle={tab === 'shared' ? 'primary' : 'default'}
+                id="clickable-nav-shared"
+              >
+                <FormattedMessage id="ui-directory.information.tab.shared" />
+              </Button>
+            }
             <Button
               onClick={() => this.setState({ tab: 'local' })}
               buttonStyle={tab === 'local' ? 'primary' : 'default'}

--- a/src/util/permissionToEdit.js
+++ b/src/util/permissionToEdit.js
@@ -1,5 +1,6 @@
 export default function permissionToEdit(stripes, record) {
-  return (stripes.hasPerm('directory.edit-all') ||
-          (stripes.hasPerm('directory.edit-self') &&
+  return (stripes.hasPerm('ui-directory.edit-all') ||
+          stripes.hasPerm('ui-directory.edit-local') ||
+          (stripes.hasPerm('ui-directory.edit-self') &&
            record?.status?.value === 'managed'));
 }


### PR DESCRIPTION
When the user has this permission but not `ui-directory.edit-all`, the
**Edit** button is enabled in the **Actions** when viewing a record,
but clicking through that button takes you to a version of the edit
form in which only the **Local information** tab is present. In
addition, it starts that tab with the **Local directory entry info**
accordion open, because why would you ever not want it to be?