### PR TITLE
make initialvalues optional for directory entry form

### DIFF
--- a/src/components/DirectoryEntryForm/DirectoryEntryForm.js
+++ b/src/components/DirectoryEntryForm/DirectoryEntryForm.js
@@ -40,7 +40,7 @@ class DirectoryEntryForm extends React.Component {
     super(props);
 
     const { stripes } = props;
-    const managed = props.initialValues.status?.value === 'managed';
+    const managed = props.initialValues?.status?.value === 'managed';
     this.localOnly = (stripes.hasPerm('ui-directory.edit-local') &&
                       !stripes.hasPerm('ui-directory.edit-all') &&
                       !(managed && stripes.hasPerm('ui-directory.edit-self')));


### PR DESCRIPTION
Trying to fix issue with manual directory entry configuration form. To replicate on east:

1. sign in, and navigate to directory app
2. chose "new" and see an error from the UI

To preview this change, do the same, but using this UI bundle built with this branch of mod-directory:
http://tmp-mod-directory.s3-website-us-east-1.amazonaws.com/
 
I don't know what I'm doing so a quick review would be appreciated.
