### PR TITLE
feat: Confirmation

### DIFF
--- a/src/components/EditDirectoryEntry/EditDirectoryEntry.js
+++ b/src/components/EditDirectoryEntry/EditDirectoryEntry.js
@@ -1,12 +1,17 @@
-import React from 'react';
+import React, { useEffect, useState } from 'react';
 import PropTypes from 'prop-types';
 import { FormattedMessage, useIntl } from 'react-intl';
 import { Form } from 'react-final-form';
 import arrayMutators from 'final-form-arrays';
 import { Prompt } from 'react-router-dom';
 
+import { useMutation } from 'react-query';
+
+import { useOkapiKy } from '@folio/stripes/core';
+
 import {
   Button,
+  ConfirmationModal,
   IconButton,
   Layout,
   Pane,
@@ -44,6 +49,15 @@ const EditDirectoryEntry = (props) => {
     stripes,
     parentResources
   } = props;
+  const ky = useOkapiKy();
+
+  const { mutateAsync: validate } = useMutation(
+    ['@reshare/ui-directory', 'validateDirectoryEntry'],
+    (data) => ky.post(`directory/entry/validate`, { json: data }).json()
+  );
+
+  const [rootWarning, setRootWarning] = useState(false);
+  const [warnings, setWarnings] = useState([]);
 
   const intl = useIntl();
 
@@ -66,7 +80,7 @@ const EditDirectoryEntry = (props) => {
     );
   };
 
-  const renderLastMenu = (pristine, submitting, submit) => {
+  const renderLastMenu = (invalid, pristine, submitting, submit, values) => {
     let id;
     let label;
     if (layer === 'edit') {
@@ -81,9 +95,11 @@ const EditDirectoryEntry = (props) => {
       <PaneMenu>
         <Button
           id={id}
-          type="submit"
-          disabled={pristine || submitting}
-          onClick={submit}
+          disabled={pristine || submitting || invalid}
+          onClick={async () => {
+            const submitFunc = await getSubmitWithValidateStep(submit, values)
+            submitFunc();
+          }} // Calculate proper submit function and execute
           buttonStyle="primary paneHeaderNewButton"
           marginBottom0
         >
@@ -91,6 +107,27 @@ const EditDirectoryEntry = (props) => {
         </Button>
       </PaneMenu>
     );
+  };
+
+  // Insert validate step into submit calls to check whether or not to raise a confirmation modal
+  // Returns a submit function.
+  const getSubmitWithValidateStep = async (submit, values) => {
+    // If this is a root entry, check validation and then raise warning modal
+    // For now the only validations we care about happen on root entries,
+    // so we can avoid a POST call otherwise. This may change in future.
+    if (layer === 'create') {
+      const validation = await validate(values);
+
+      // TODO in future we may also pass validation.errors.
+      // Those should also be handled in this logic, eg slug is not unique pre-attempt to POST
+      if (validation?.warnings?.length) {
+        setWarnings(validation.warnings?.map(warning => <FormattedMessage id={`ui-directory.directoryEntry.warning.${warning}`} />));
+        return () => setRootWarning(true);
+      }
+    }
+    
+    // If none of the above applies, just return submit function as is
+    return submit;
   };
 
   const selectPlugin = (domain) => {
@@ -134,8 +171,8 @@ const EditDirectoryEntry = (props) => {
   // TODO this seems like terrible code...
   // This allows the initial values to hold the current parent value
   if (initialValues) {
-    initialValues.parent = initialValues.parent?.id;
-    initialValues.type = initialValues.type?.id;
+    initialValues.parent = initialValues.parent?.id ?? initialValues.parent;
+    initialValues.type = initialValues.type?.id ?? initialValues.type;
 
     if (initialValues.services) {
       const newServices = [];
@@ -206,22 +243,43 @@ const EditDirectoryEntry = (props) => {
         ...arrayMutators,
       }}
     >
-      {({ form, handleSubmit, pristine, submitting, submitSucceeded, values }) => (
-        <form id="form-directory-entry">
-          <Pane
-            defaultWidth="100%"
-            firstMenu={renderFirstMenu()}
-            lastMenu={renderLastMenu(pristine, submitting, handleSubmit)}
-            paneTitle={paneTitle}
-          >
-            <Layout className="centered" style={{ maxWidth: '80em' }}>
-              <DirectoryEntryForm values={values} form={form} {...props} />
-              <FormattedMessage id="ui-directory.confirmDirtyNavigate">
-                {prompt => <Prompt when={!pristine && !(submitting || submitSucceeded)} message={prompt} />}
-              </FormattedMessage>
-            </Layout>
-          </Pane>
-        </form>
+      {({ form, handleSubmit, invalid, pristine, submitting, submitSucceeded, values }) => (
+        <>
+          <form id="form-directory-entry">
+            <Pane
+              defaultWidth="100%"
+              firstMenu={renderFirstMenu()}
+              lastMenu={renderLastMenu(invalid, pristine, submitting, handleSubmit, values)}
+              paneTitle={paneTitle}
+            >
+              <Layout className="centered" style={{ maxWidth: '80em' }}>
+                <DirectoryEntryForm values={values} form={form} {...props} />
+                <FormattedMessage id="ui-directory.confirmDirtyNavigate">
+                  {prompt => <Prompt when={!pristine && !(submitting || submitSucceeded)} message={prompt} />}
+                </FormattedMessage>
+              </Layout>
+            </Pane>
+          </form>
+          <ConfirmationModal
+            heading={<FormattedMessage id="ui-directory.directoryEntry.confirmationModal.header" />}
+            message={
+              <>
+                <strong><FormattedMessage id="ui-directory.directoryEntry.confirmationModal.message" /></strong>
+                {warnings.map(warning => <div>{warning}</div>)}
+              </>
+            }
+            onCancel={() => {
+              setRootWarning(false); // Close modal
+              setWarnings([]); // Reset warnings
+            }}
+            onConfirm={() => {
+              handleSubmit(); // Submit entry
+              setRootWarning(false); // Close modal
+              setWarnings([]); // Reset warnings
+            }}
+            open={rootWarning}
+          />
+        </>
       )}
     </Form>
   );

--- a/translations/ui-directory/en.json
+++ b/translations/ui-directory/en.json
@@ -141,5 +141,10 @@
   "permission.ui-directory.edit-self": "Directory: edit the directory entry of the present institution",
   "permission.ui-directory.edit-local": "Directory: edit the local fields of directory entries",
   "permission.ui-directory.edit-all": "Directory: edit all directory entries",
-  "permission.ui-directory.create": "Directory: create new directory entries"
+  "permission.ui-directory.create": "Directory: create new directory entries",
+  
+  "directoryEntry.confirmationModal.header": "Confirm directory entry creation",
+  "directoryEntry.confirmationModal.message": "Warning. Please confirm directory entry creation.",
+  "directoryEntry.warning.managedInstitutionAlreadyExists": "A managed root entry already exists for type 'Institution' for your tenant in this ReShare system. If you meant to add a Branch record for your tenant please select your tenant's Institution record and under Actions choose Create Unit and select Branch in the Type field.",
+  "directoryEntry.warning.consortiumAlreadyExists": "An root entry already exists for type 'Consortium' in this ReShare system. Adding a second Consortium directory record is not recommended. If you meant to add an Institution record please update the entry in the Type field accordingly before creating the record. If you meant to add a Branch record please find the Institution record you wish to add a branch for and under Actions choose Create Unit and select Branch in the Type field."
 }


### PR DESCRIPTION
Added pre-submit call to a new `validate` endpoint, which will surface warnings about counts of consortium/managed institution records in the database. In future this same endpoint could be used for real time field validations, such as uniqueness of slug, but for now it only surfaces these warnings and 0 errors.

PR-1107